### PR TITLE
ci: remove semantic-release environment from workflow

### DIFF
--- a/.github/workflows/publish-nuget-example.yml
+++ b/.github/workflows/publish-nuget-example.yml
@@ -14,7 +14,6 @@ jobs:
   release:
 
     runs-on: ubuntu-latest
-    environment: semantic-release
 
     permissions:
       contents: write


### PR DESCRIPTION
Previously I had experimented with this, but apparently wasn't even using this anymore, so it's been removed. Doesn't really make sense to use an environment here.